### PR TITLE
ci: moved to public repo and codecov v2 token for proper code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           pytest --cov=src --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v2
         with:
           files: coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
CI updates

## Summary by Sourcery

Update GitHub Actions workflow to use Codecov v2 and add fail-on-error configuration

CI:
- Updated Codecov GitHub Action from v3 to v2
- Added fail_ci_if_error option to Codecov upload step