### PR TITLE
ci: enhance test coverage reporting and inspection steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,23 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=src --cov-report=xml
+          pytest \
+            --cov=safechess \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing \
+            tests/
+
+      - name: Dump coverage.xml for inspection
+        run: |
+          echo "=== coverage.xml contents ==="
+          head -n 30 coverage.xml || true
+          echo "=== End of snippet ==="
+          wc -l coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
+          verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
TO ensure that codecov is getting the coverage reports and data it requires

## Summary by Sourcery

Enhance CI test coverage reporting by adjusting pytest coverage output, adding an inspection step for coverage.xml, and increasing verbosity in the Codecov upload

CI:
- Configure pytest to produce XML coverage output as coverage.xml and include a term-missing report
- Add a CI step to display the first 30 lines and line count of coverage.xml for inspection
- Enable verbose logging in the Codecov upload action